### PR TITLE
Added CSRF protection with plone.protect.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added CSRF protection with plone.protect.
+  [phgross]
 
 
 1.3.4 (2013-04-17)

--- a/ftw/dashboard/portlets/postit/browser/postit.py
+++ b/ftw/dashboard/portlets/postit/browser/postit.py
@@ -30,7 +30,6 @@ class IPostItPortlet(IPortletDataProvider):
     """
 
 
-
 class Assignment(base.Assignment):
     implements(IPostItPortlet)
 
@@ -57,7 +56,7 @@ class Renderer(base.Renderer):
     def notes(self):
         return self.data.notes
 
-    #XXX: @ram.cache(_render_cachekey)
+    # XXX: @ram.cache(_render_cachekey)
     def render(self):
         return xhtml_compress(self._template())
 
@@ -91,6 +90,7 @@ def get_column_and_portlet(context, portlet_info):
                                       portlet_info['name'])
     return column, portlet
 
+
 class AddNote(BrowserView):
 
     def __call__(self, *args, **kwargs):
@@ -111,7 +111,6 @@ class AddNote(BrowserView):
         portlet.notes = notes[:]
 
 
-
 class RemoveNote(BrowserView):
 
     def __call__(self, *args, **kwargs):
@@ -122,5 +121,5 @@ class RemoveNote(BrowserView):
         column, portlet = get_column_and_portlet(self.context, portlet_info)
         # remove note
         notes = portlet.notes[:]
-        notes = notes[0:index] + notes[index+1:]
+        notes = notes[0:index] + notes[index + 1:]
         portlet.notes = notes[:]

--- a/ftw/dashboard/portlets/postit/browser/postit.py
+++ b/ftw/dashboard/portlets/postit/browser/postit.py
@@ -1,20 +1,28 @@
+from ftw.dashboard.portlets.postit import _
+from ftw_formhelper import ftwNullAddForm
+from plone.app.portlets.cache import render_cachekey
+from plone.app.portlets.portlets import base
+from plone.app.portlets.utils import assignment_from_key
+from plone.memoize.compress import xhtml_compress
+from plone.portlets.constants import USER_CATEGORY
+from plone.portlets.interfaces import IPortletDataProvider
+from plone.portlets.interfaces import IPortletManager
+from plone.portlets.utils import unhashPortletInfo
+from Products.CMFCore.utils import getToolByName
+from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zExceptions import Unauthorized
 from zope.component import getUtility
 from zope.interface import implements
 
-from plone.app.portlets.portlets import base
-from plone.memoize.compress import xhtml_compress
-from plone.portlets.interfaces import IPortletDataProvider
-from plone.app.portlets.cache import render_cachekey
-from plone.app.portlets.utils import assignment_from_key
-from plone.portlets.utils import unhashPortletInfo
-from plone.portlets.interfaces import IPortletManager
-from plone.portlets.constants import USER_CATEGORY
-from Products.Five import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from ftw.dashboard.portlets.postit import _
-from ftw_formhelper import ftwNullAddForm
-from Products.CMFCore.utils import getToolByName
-from zExceptions import Unauthorized
+
+# Try to get the plone.protect's createToken method, because it's only
+# available since version 2.0.2, otherwise we just use a mocked method.
+try:
+    from plone.protect import createToken
+except ImportError:
+    def createToken():
+        return ''
 
 
 class IPostItPortlet(IPortletDataProvider):
@@ -57,6 +65,8 @@ class Renderer(base.Renderer):
     def title(self):
         return self.data.title
 
+    def authenticator_token(self):
+        return createToken()
 
 
 class AddForm(ftwNullAddForm):
@@ -114,6 +124,3 @@ class RemoveNote(BrowserView):
         notes = portlet.notes[:]
         notes = notes[0:index] + notes[index+1:]
         portlet.notes = notes[:]
-
-
-

--- a/ftw/dashboard/portlets/postit/browser/resources/postit.js
+++ b/ftw/dashboard/portlets/postit/browser/resources/postit.js
@@ -1,5 +1,7 @@
 jQuery(function($) {
 
+    var authenticator_token = $('.portletPostIt').data('authenticator-token');
+
     // REFRESH ODD / EVEN
     var refreshOddEven = function(jqElm){
         var odd = false;
@@ -24,6 +26,9 @@ jQuery(function($) {
         $.ajax({
             type :      'POST',
             url :       './@@ftw.postit-addnote',
+            beforeSend: function (request){
+              request.setRequestHeader("X-CSRF-TOKEN", authenticator_token);
+            },
             data :      {
                     hash : hash,
                     note : text
@@ -58,6 +63,9 @@ jQuery(function($) {
         $.ajax({
             type :          'POST',
             url :           './@@ftw.postit-removenote',
+            beforeSend: function (request){
+              request.setRequestHeader("X-CSRF-TOKEN", authenticator_token);
+            },
             data :          {
                     hash : hash,
                     index : index

--- a/ftw/dashboard/portlets/postit/browser/templates/postit.pt
+++ b/ftw/dashboard/portlets/postit/browser/templates/postit.pt
@@ -1,4 +1,5 @@
 <dl class="portlet postit portletPostIt"
+    tal:attributes="data-authenticator-token view/authenticator_token"
     i18n:domain="plone">
 
     <dt class="portletHeader">


### PR DESCRIPTION
The CSRF protection will only work if plone.protect is in the version 2.0.2 or higher (see https://github.com/plone/plone.protect/blob/2.0.2/plone/protect/__init__.py#L5 for more details).

@jone, @lukasgraf 
